### PR TITLE
Update .gitignore ; ignoring .DS_Store (macOS hidden files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+.DS_Store


### PR DESCRIPTION
.DS_Store are hidden macOS files for storing per directory informations such as viewing in Finder. Must be ignored.